### PR TITLE
feat(cpu): Implementing MOVS instructions and its tests.

### DIFF
--- a/src/RP2040.Core/Cpu/InstructionDecoder.cs
+++ b/src/RP2040.Core/Cpu/InstructionDecoder.cs
@@ -157,7 +157,7 @@ public unsafe class InstructionDecoder : IDisposable
 			// CMP Rn, #imm8
 			new OpcodeRule (0xF800, 0x2800, &ArithmeticOps.CmpImmediate),
 			// MOVS (Rd, #imm8)
-			new OpcodeRule (0xF800, 0x2000, &BitOps.MovsImm8),
+			new OpcodeRule (0xF800, 0x2000, &BitOps.Movs),
 			// LDMIA (Load Multiple Increment After)
 			new OpcodeRule(0xF800, 0xC800, &MemoryOps.Ldmia),
 

--- a/src/RP2040.Core/Cpu/Instructions/BitOps.cs
+++ b/src/RP2040.Core/Cpu/Instructions/BitOps.cs
@@ -148,15 +148,13 @@ public static class BitOps
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static void MovsImm8(ushort opcode, CortexM0Plus cpu)
+	public static void Movs(ushort opcode, CortexM0Plus cpu)
 	{
 		var value = (uint)(opcode & 0xFF);
-		var rd = (opcode >> 8) & 7;
 
-		ref var ptrRd = ref cpu.Registers[rd];
-		ptrRd = value;
+		cpu.Registers[(opcode >> 8) & 7] = value;
 		
-		cpu.Registers.N = false; // imm8 is always positive (0-255)
+		cpu.Registers.N = false;
 		cpu.Registers.Z = value == 0;
 	}
 	

--- a/src/RP2040.Core/Helpers/InstructionEmiter.cs
+++ b/src/RP2040.Core/Helpers/InstructionEmiter.cs
@@ -181,7 +181,7 @@ public static class InstructionEmiter
 		return (ushort)(0x4600 | ((rd & 8) << 4) | ((rm & 0xF) << 3) | (rd & 7));
 	}
 
-	public static ushort MovsImm8 (uint rd, uint imm8)
+	public static ushort Movs (uint rd, uint imm8)
 	{
 		if (rd > 15) throw new ArgumentException("Register index out of range (0-15)");
 		if (imm8 > 255) throw new ArgumentException("Immediate too large for MOVS");

--- a/tests/RP2040.Core.Tests/Cpu/Instructions/BitOpsTests.cs
+++ b/tests/RP2040.Core.Tests/Cpu/Instructions/BitOpsTests.cs
@@ -342,35 +342,7 @@ public class BitOpsTests
 			// Assert
 			_cpu.Registers[SP].Should ().Be (52);
 		}
-	}
 
-	public class MovsImm8
-	{
-		private readonly CortexM0Plus _cpu;
-		private readonly BusInterconnect _bus;
-
-		public MovsImm8()
-		{
-			_bus = new BusInterconnect();
-			_cpu = new CortexM0Plus(_bus);
-			_cpu.Registers.PC = 0x20000000;
-		}
-
-		[Fact]
-		public void ShouldExecute ()
-		{
-			// Arrange
-			var opcode = InstructionEmiter.MovsImm8 (R5, 128);
-			_bus.WriteHalfWord (0x20000000, opcode);
-			
-			// Act
-			_cpu.Step();
-			
-			// Assert
-			_cpu.Registers[R5].Should().Be(128);
-			_cpu.Registers.PC.Should().Be(0x20000002);
-		}
-		
 		[Fact]
 		public void MOV_Should_Clear_Lower_2Bits_Of_SP()
 		{
@@ -399,6 +371,35 @@ public class BitOpsTests
     
 			_cpu.Registers.PC.Should().Be(0x52); 
 		}
+	}
+
+	public class Movs
+	{
+		private readonly CortexM0Plus _cpu;
+		private readonly BusInterconnect _bus;
+
+		public Movs()
+		{
+			_bus = new BusInterconnect();
+			_cpu = new CortexM0Plus(_bus);
+			_cpu.Registers.PC = 0x20000000;
+		}
+
+		[Fact]
+		public void ShouldExecute ()
+		{
+			// Arrange
+			var opcode = InstructionEmiter.Movs (R5, 128);
+			_bus.WriteHalfWord (0x20000000, opcode);
+			
+			// Act
+			_cpu.Step();
+			
+			// Assert
+			_cpu.Registers[R5].Should().Be(128);
+			_cpu.Registers.PC.Should().Be(0x20000002);
+		}
+	
 	}
 	
 	[Fact]


### PR DESCRIPTION
The only test that left is "MOVS_Register_Should_Copy_Value" because MovsReg is not implemented.

## Description
## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Refactoring (no functional changes, just code cleanup)

## Checklist
- [ ] 🧪 Tests passed locally (`dotnet test`)
- [ ] ✅ Added new tests for this feature/fix
- [ ] 📝 Documentation updated (if applicable)
- [ ] 🚫 No "Magic Strings" or hardcoded values
- [ ] 💾 Validated against the RP2040 Datasheet (if applicable)

## Screenshots / Hex Dumps (Optional)