### PR TITLE
fix(build): set MinVerTagPrefix to v so version tags are recognized

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- MinVer: versioning automático desde git tags (v1.0.0) -->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerVerbosity>minimal</MinVerVerbosity>
     <MinVerDefaultPreReleaseIdentifiers>preview</MinVerDefaultPreReleaseIdentifiers>
     <!-- Shared across all projects -->


### PR DESCRIPTION
## Description
## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Refactoring (no functional changes, just code cleanup)

## Checklist
- [ ] 🧪 Tests passed locally (`dotnet test`)
- [ ] ✅ Added new tests for this feature/fix
- [ ] 📝 Documentation updated (if applicable)
- [ ] 🚫 No "Magic Strings" or hardcoded values
- [ ] 💾 Validated against the RP2040 Datasheet (if applicable)

## Screenshots / Hex Dumps (Optional)